### PR TITLE
Removed the "Backbone Conventions" comment

### DIFF
--- a/source/_posts/2013-12-28-the-good-the-bad-and-the-ugly-of-sails-dot-js-realtime-javascript-mvc-framework.markdown
+++ b/source/_posts/2013-12-28-the-good-the-bad-and-the-ugly-of-sails-dot-js-realtime-javascript-mvc-framework.markdown
@@ -31,7 +31,6 @@ module.exports = {
 Sails uses [Waterline](https://npmjs.org/package/waterline) as its ORM, and it provides a lot of power for developing rapidly.  The `adapter` field dictates where the data will be stored, and you can mix and match, so you can have some models stored in MySQL and others in Redis, for instance.  I think this is a really cool feature.  You can set validation, etc. on them.  You can write custom methods on your models to extract "higher-order" data from them.  Best of all, just having a model gets you a ton of routes (CRUD blueprints and REST endpionts) out of the box (and they [all work with Websockets](http://sailsjs.org/#!documentation/sockets)!):
 
 ```
-# Backbone Conventions
 GET   :    /:controller                 => findAll()
 GET   :    /:controller/read/:id        => find(id)
 POST  :    /:controller/create          => create()


### PR DESCRIPTION
The routes described underneath that comment are not "Backbone conventions", as far as i'm able to tell. Backbone conventions would be more like

```
GET      : /:collection      => findAll()
GET      : /:collection/:id  => find(id)
PATCH    : /:collection/:id  => update(id)
etc..
```

e.g, it uses HTTP verbs on whatever the root url of your model collection is (with the model ID appended after a slash) by default. There's no `read`, `create`, etc. in the way URLs are built by default.

The way Sails is set up kind of looks like old school Rails conventions maybe? I couldn't say, it's been a while since I've used Rails.
