### PR TITLE
correct $http then() handling

### DIFF
--- a/source/_posts/2014-01-04-5-smooth-angularjs-application-tips.markdown
+++ b/source/_posts/2014-01-04-5-smooth-angularjs-application-tips.markdown
@@ -162,7 +162,7 @@ app.factory('githubService', function($http) {
 app.controller('MainCtrl', function($scope, githubService) {
 	// assuming $scope.username is set with ng-model
 	githubService.getUserInfo($scope.username).then(function(data) {
-		$scope.userInfo = data;
+		$scope.userInfo = data.data;
 	});
 });
 ```


### PR DESCRIPTION
$http's `success` and `failure` separate out all the data into 4 arguments (data, headers, etc.) while `then` leaves it all in data, so the information you want is in data.data
