### PR TITLE
fix: use latest single-binary version of diff-highlight

### DIFF
--- a/content/post/on-the-matter-of-beautiful-git-diffs.markdown
+++ b/content/post/on-the-matter-of-beautiful-git-diffs.markdown
@@ -31,7 +31,7 @@ To download, you could do something like:
 
 <pre>
 $ sudo wget \
-    https://raw.githubusercontent.com/git/git/master/contrib/diff-highlight/diff-highlight \
+    https://raw.githubusercontent.com/git/git/3dbfe2b8ae94cbdae5f3d32581aedaa5510fdc87/contrib/diff-highlight/diff-highlight \
     -O /usr/local/bin/diff-highlight
 </pre>
 


### PR DESCRIPTION
Master separates this out into modules, and requires compilation (for no benefits to diff-highlight users).