### PR TITLE
Remove unused global variable in the example code

### DIFF
--- a/content/post/youre-not-using-this-enough-part-one-go-interfaces.markdown
+++ b/content/post/youre-not-using-this-enough-part-one-go-interfaces.markdown
@@ -90,10 +90,6 @@ type Config interface {
     Set(key, val string) error
 }
 
-var (
-    Cfg InmemConfig
-)
-
 type InmemConfig struct {
     M map[string]string
 }


### PR DESCRIPTION
In the first example, global variable Cfg is not used.  Can we remove it?