### PR TITLE
Update handling-ctrl-c-interrupt-signal-in-golang-programs.markdown

### DIFF
--- a/content/post/handling-ctrl-c-interrupt-signal-in-golang-programs.markdown
+++ b/content/post/handling-ctrl-c-interrupt-signal-in-golang-programs.markdown
@@ -23,14 +23,13 @@ Here is some sample source code:
 // Wait for a SIGINT (perhaps triggered by user with CTRL-C)
 // Run cleanup when signal is received
 signalChan := make(chan os.Signal, 1)
-cleanupDone := make(chan bool)
+cleanupDone := make(chan struct{})
 signal.Notify(signalChan, os.Interrupt)
 go func() {
-    for _ = range signalChan {
-        fmt.Println("\nReceived an interrupt, stopping services...\n")
-        cleanup(services, c)
-        cleanupDone <- true
-    }
+    <-signalChan
+    fmt.Println("\nReceived an interrupt, stopping services...\n")
+    cleanup(services, c)
+    close(cleanupDone)
 }()
 <-cleanupDone
 ```


### PR DESCRIPTION
Ranging over signalChan is misleading since the program will terminate immediately after signaling cleanupDone. It's also a bit more idiomatic to use a chan struct{} and close it if the channel is solely for signaling completion.

/cc @nathanleclaire 