### PR TITLE
Grammar fixes for "Handling CTRL-C (interrupt signal) in Golang Programs"

### DIFF
--- a/content/post/handling-ctrl-c-interrupt-signal-in-golang-programs.markdown
+++ b/content/post/handling-ctrl-c-interrupt-signal-in-golang-programs.markdown
@@ -10,7 +10,7 @@ categories: [golang,sigint,ctrl-c]
 
 {{%img src="/images/signal.png" caption="" %}}
 
-Recently I've been working on a Go program where I will need to do some cleanup work before exiting if the users press `CTRL+C` (thereby sending an interrupt signal, `SIGINT`, to the process).  I was unsure how to do this.
+Recently I've been working on a Go program where I will need to do some cleanup work before exiting if the users press `CTRL+C` (thereby sending an interrupt signal, `SIGINT`, to the process).  I was unsure of how to do this.
 
 As it turns out, `signal.Notify` is the method by which this is accomplished.
 
@@ -34,9 +34,9 @@ go func() {
 <-cleanupDone
 ```
 
-I like this example because it really illuminates the power of Go's concurrency primitives.  Instead of having to worry about complicated process or threading logic I simply abstract away the concurrency details using a goroutine and a couple of channels. In this instance, the main goroutine is blocked by a unbuffered `cleanupDone` channel because that is what behavior is expected (we've already spin up additional goroutines earlier to do some logging and handling of outside of the context of the main goroutine). 
+I like this example because it really illuminates the power of Go's concurrency primitives.  Instead of having to worry about complicated process or threading logic I simply abstract away the concurrency details using a goroutine and a couple of channels. In this instance, the main goroutine is blocked by an unbuffered `cleanupDone` channel because that is the behavior that is expected (we've already spun up additional goroutines earlier to do some logging and handling outside of the context of the main goroutine). 
 
-Now I can clean up after my containers when a user interrupts the terminal with CTRL+C.  Awesome!
+Now I can clean up after my containers when a user interrupts the terminal with `CTRL+C`.  Awesome!
 
 Until next time, stay sassy Internet.
 


### PR DESCRIPTION
These proposed changes are simply grammatical fixes to make the entry a little easier to read for OCD freaks like me. Enjoy!