### PR TITLE
Golang goroutine

### DIFF
--- a/content/post/how-to-wait-for-all-goroutines-to-finish-executing-before-continuing.markdown
+++ b/content/post/how-to-wait-for-all-goroutines-to-finish-executing-before-continuing.markdown
@@ -160,6 +160,7 @@ func main() {
         messages <- 3
     }()
     go func() {
+        // we should wait for completion here?
         for i := range messages {
             fmt.Println(i)
         }


### PR DESCRIPTION
Are we correctly waiting for result processing?

Since we only wait on `wg.Wait()` it could return before all the println have happened since we dont wait for that.
We should somehow also have a mechanism to wait for all the messages to have been processed. Im still trying to think what would be the cleanest solution.